### PR TITLE
Ikarus loop support

### DIFF
--- a/include/phoenix/script.hh
+++ b/include/phoenix/script.hh
@@ -40,11 +40,12 @@ namespace phoenix {
 
 	/// \brief Flags of symbols.
 	namespace symbol_flag {
-		static constexpr auto const_ = 1U << 0U;   ///< The symbol is not mutable.
-		static constexpr auto return_ = 1U << 1U;  ///< The symbol is a function and has a return value.
-		static constexpr auto member = 1U << 2U;   ///< The symbol is a class member.
-		static constexpr auto external = 1U << 3U; ///< The symbol refers to an external function.
-		static constexpr auto merged = 1U << 4U;   ///< Unused.
+		static constexpr auto const_ = 1U << 0U;      ///< The symbol is not mutable.
+		static constexpr auto return_ = 1U << 1U;     ///< The symbol is a function and has a return value.
+		static constexpr auto member = 1U << 2U;      ///< The symbol is a class member.
+		static constexpr auto external = 1U << 3U;    ///< The symbol refers to an external function.
+		static constexpr auto merged = 1U << 4U;      ///< Unused.
+		static constexpr auto access_trap = 1U << 6U; ///< VM should call trap callback, when symbol accessed.
 	}                                              // namespace symbol_flag
 
 	/// \brief All opcodes supported by the daedalus interpreter.
@@ -447,6 +448,10 @@ namespace phoenix {
 			    this->get_instance()->_m_type == &typeid(T);
 		}
 
+		/// \brief Allows VM traps on access to this symbol
+		/// \param enable true to enable and false to disable
+		PHOENIX_API void set_access_trap_enable(bool enable) noexcept;
+
 		/// \brief Tests whether the symbol is a constant.
 		/// \return `true` if the symbol is a constant, `false` if not.
 		[[nodiscard]] PHOENIX_API inline bool is_const() const noexcept {
@@ -472,6 +477,11 @@ namespace phoenix {
 			return (_m_flags & symbol_flag::merged) != 0;
 		}
 
+		/// \brief Tests whether the symbol has access trap.
+		/// \return `true` if the symbol has trap enabled, `false` if not.
+		[[nodiscard]] PHOENIX_API inline bool has_access_trap() const noexcept {
+			return (_m_flags & symbol_flag::access_trap) != 0;
+		}
 		/// \brief brief Tests whether the symbol is a compiler-generated symbol
 		/// \return return `true` if the symbol is generated, `false` if not.
 		[[nodiscard]] PHOENIX_API inline bool is_generated() const noexcept {

--- a/include/phoenix/vm.hh
+++ b/include/phoenix/vm.hh
@@ -720,7 +720,7 @@ namespace phoenix {
 		/// \note Requires that sizeof...(Px) + 1 == defined.size().
 		template <int32_t i, typename P, typename... Px>
 		void check_external_params(const std::vector<symbol*>& defined) {
-			if constexpr (is_instance_ptr_v<P> || is_raw_instance_ptr_v<P>) {
+			if constexpr (is_instance_ptr_v<P> || std::is_same_v<symbol*, P> || is_raw_instance_ptr_v<P>) {
 				if (defined[i]->type() != datatype::instance)
 					throw illegal_external_param(defined[i], "instance", i + 1);
 			} else if constexpr (std::is_same_v<float, P>) {
@@ -883,7 +883,7 @@ namespace phoenix {
 		                            std::is_same_v<std::remove_reference_t<P>, symbol*>,
 		                        void>::type
 		push_call_parameters(const std::vector<symbol*>& defined, P value, Px... more) { // clang-format on
-			if constexpr (is_instance_ptr_v<P> || std::is_same_v<symbol*, P> || is_raw_instance_ptr_v<P>) {
+			if constexpr (is_instance_ptr_v<P> || std::is_same_v<symbol*, P>) {
 				if (defined[i]->type() != datatype::instance)
 					throw illegal_external_param(defined[i], "instance", i + 1);
 

--- a/include/phoenix/vm.hh
+++ b/include/phoenix/vm.hh
@@ -883,7 +883,7 @@ namespace phoenix {
 		                            std::is_same_v<std::remove_reference_t<P>, symbol*>,
 		                        void>::type
 		push_call_parameters(const std::vector<symbol*>& defined, P value, Px... more) { // clang-format on
-			if constexpr (is_instance_ptr_v<P> || std::is_same_v<symbol*, P>) {
+			if constexpr (is_instance_ptr_v<P> || std::is_same_v<symbol*, P> || is_raw_instance_ptr_v<P>) {
 				if (defined[i]->type() != datatype::instance)
 					throw illegal_external_param(defined[i], "instance", i + 1);
 

--- a/include/phoenix/vm.hh
+++ b/include/phoenix/vm.hh
@@ -931,7 +931,7 @@ namespace phoenix {
 		std::unordered_map<symbol*, std::function<void(vm&)>> _m_externals;
 		std::unordered_map<uint32_t, std::function<void(vm&)>> _m_function_overrides;
 		std::optional<std::function<void(vm&, symbol&)>> _m_default_external {std::nullopt};
-		std::function<void(symbol&)> _m_default_loop_trap;
+		std::function<void(symbol&)> _m_loop_trap;
 		std::optional<std::function<vm_exception_strategy(vm&, const script_error&, const instruction&)>>
 		    _m_exception_handler {std::nullopt};
 

--- a/include/phoenix/vm.hh
+++ b/include/phoenix/vm.hh
@@ -556,26 +556,22 @@ namespace phoenix {
 
 			// *evil template hacking ensues*
 			_m_function_overrides[sym->address()] = [callback, sym](vm& machine) {
+				machine.push_call(sym);
 				if constexpr (std::is_same_v<void, R>) {
-					machine.push_call(sym);
 					if constexpr (sizeof...(P) > 0) {
 						auto v = machine.pop_values_for_external<P...>();
 						std::apply(callback, v);
 					} else {
 						callback();
 					}
-					machine.pop_call();
-				} else if constexpr (std::is_same_v<phoenix::naked_call, R>){
-					callback(machine);
 				} else {
-					machine.push_call(sym);
 					if constexpr (sizeof...(P) > 0) {
 						machine.push_value_from_external(std::apply(callback, machine.pop_values_for_external<P...>()));
 					} else {
 						machine.push_value_from_external(callback());
 					}
-					machine.pop_call();
 				}
+				machine.pop_call();
 			};
 
 			PX_LOGD("vm: overrode function ", sym->name());

--- a/include/phoenix/vm.hh
+++ b/include/phoenix/vm.hh
@@ -85,7 +85,6 @@ namespace phoenix {
 		static constexpr std::uint8_t none = 0;
 		static constexpr std::uint8_t vm_allow_null_instance_access = 1 << 1;
 		static constexpr std::uint8_t vm_ignore_const_specifier = 1 << 2;
-		static constexpr std::uint8_t vm_allow_loop_traps = 1 << 3;
 	} // namespace execution_flag
 
 	class vm : public script {
@@ -609,7 +608,7 @@ namespace phoenix {
 
 		PHOENIX_API void register_default_external_custom(const std::function<void(vm&, symbol&)>& callback);
 
-		PHOENIX_API void register_loop_trap(const std::function<void (symbol &)> &callback);
+		PHOENIX_API void register_access_trap(const std::function<void (symbol &)> &callback);
 
 		/// \brief Registers a function to be called when script execution fails.
 		///
@@ -931,7 +930,7 @@ namespace phoenix {
 		std::unordered_map<symbol*, std::function<void(vm&)>> _m_externals;
 		std::unordered_map<uint32_t, std::function<void(vm&)>> _m_function_overrides;
 		std::optional<std::function<void(vm&, symbol&)>> _m_default_external {std::nullopt};
-		std::function<void(symbol&)> _m_loop_trap;
+		std::function<void(symbol&)> _m_access_trap;
 		std::optional<std::function<vm_exception_strategy(vm&, const script_error&, const instruction&)>>
 		    _m_exception_handler {std::nullopt};
 
@@ -942,10 +941,6 @@ namespace phoenix {
 		symbol* _m_item_sym;
 
 		symbol* _m_temporary_strings;
-
-		symbol* _m_loop_end_sym {};
-		symbol* _m_loop_break_sym {};
-		symbol* _m_loop_continue_sym {};
 
 		std::shared_ptr<instance> _m_instance;
 		std::uint32_t _m_pc {0};

--- a/include/phoenix/vm.hh
+++ b/include/phoenix/vm.hh
@@ -532,7 +532,7 @@ namespace phoenix {
 				} else {
 					throw vm_exception {"unsupported return type"};
 				}
-			} else if (!std::is_same_v<naked_call, R>){
+			} else if (!std::is_same_v<naked_call, R>) {
 				if (sym->has_return())
 					throw illegal_external_rtype(sym, "void");
 			}

--- a/source/script.cc
+++ b/source/script.cc
@@ -456,4 +456,11 @@ namespace phoenix {
 
 		std::get<std::shared_ptr<instance>>(_m_value) = inst;
 	}
+
+	void symbol::set_access_trap_enable(bool enable) noexcept {
+		if (enable)
+			_m_flags |= symbol_flag::access_trap;
+		else
+			_m_flags &= ~symbol_flag::access_trap;
+	}
 } // namespace phoenix

--- a/source/vm.cc
+++ b/source/vm.cc
@@ -80,12 +80,6 @@ namespace phoenix {
 		_m_hero_sym = find_symbol_by_name("HERO");
 		_m_item_sym = find_symbol_by_name("ITEM");
 		_m_temporary_strings = add_temporary_strings_symbol();
-
-		if (_m_flags & execution_flag::vm_allow_loop_traps) {
-			_m_loop_end_sym = find_symbol_by_name("END");
-			_m_loop_break_sym = find_symbol_by_name("BREAK");
-			_m_loop_continue_sym = find_symbol_by_name("CONTINUE");
-		}
 	}
 
 	void vm::unsafe_call(const symbol* sym) {
@@ -267,8 +261,8 @@ namespace phoenix {
 				if (sym == nullptr) {
 					throw vm_exception {"pushv: no symbol found for index"};
 				}
-				if ((_m_loop_end_sym == sym || _m_loop_break_sym==sym || _m_loop_continue_sym==sym) && _m_loop_trap) {
-					_m_loop_trap(*sym);
+				if (sym->has_access_trap() && _m_access_trap) {
+					_m_access_trap(*sym);
 				} else {
 					push_reference(sym, 0);
 				}
@@ -671,10 +665,10 @@ namespace phoenix {
 		_m_default_external = callback;
 	}
 
-	void vm::register_loop_trap(const std::function<void (symbol &)> &callback) {
-		if (!(_m_flags & execution_flag::vm_allow_loop_traps))
-			throw vm_exception {"Loop traps are not enabled"};
-		_m_loop_trap = callback;
+	void vm::register_access_trap(const std::function<void (symbol &)> &callback) {
+		_m_access_trap = callback;
+	}
+
 	}
 
 	void vm::register_exception_handler(

--- a/source/vm.cc
+++ b/source/vm.cc
@@ -672,7 +672,7 @@ namespace phoenix {
 	}
 
 	void vm::register_loop_trap(const std::function<void (symbol &)> &callback) {
-		if (_m_flags & execution_flag::vm_allow_loop_traps)
+		if (!(_m_flags & execution_flag::vm_allow_loop_traps))
 			throw vm_exception {"Loop traps are not enabled"};
 		_m_default_loop_trap = callback;
 	}

--- a/source/vm.cc
+++ b/source/vm.cc
@@ -669,8 +669,6 @@ namespace phoenix {
 		_m_access_trap = callback;
 	}
 
-	}
-
 	void vm::register_exception_handler(
 	    const std::function<vm_exception_strategy(vm&, const script_error&, const instruction&)>& callback) {
 		_m_exception_handler = callback;

--- a/source/vm.cc
+++ b/source/vm.cc
@@ -267,8 +267,8 @@ namespace phoenix {
 				if (sym == nullptr) {
 					throw vm_exception {"pushv: no symbol found for index"};
 				}
-				if ((_m_loop_end_sym == sym || _m_loop_break_sym==sym || _m_loop_continue_sym==sym) && _m_default_loop_trap) {
-					_m_default_loop_trap(*sym);
+				if ((_m_loop_end_sym == sym || _m_loop_break_sym==sym || _m_loop_continue_sym==sym) && _m_loop_trap) {
+					_m_loop_trap(*sym);
 				} else {
 					push_reference(sym, 0);
 				}
@@ -674,7 +674,7 @@ namespace phoenix {
 	void vm::register_loop_trap(const std::function<void (symbol &)> &callback) {
 		if (!(_m_flags & execution_flag::vm_allow_loop_traps))
 			throw vm_exception {"Loop traps are not enabled"};
-		_m_default_loop_trap = callback;
+		_m_loop_trap = callback;
 	}
 
 	void vm::register_exception_handler(


### PR DESCRIPTION
Concept:

* `CONTINUE`, `BREAK` and `END` are tracked in VM (guarded by flag), assuming that it's more efficient than virtual functions based approach.
* Added unsafe_jump function and naked calls to assist with `repeat` function
* Added naked_call to assist with `repeat` function