### PR TITLE
transient and opaque instances

### DIFF
--- a/include/phoenix/script.hh
+++ b/include/phoenix/script.hh
@@ -274,11 +274,14 @@ namespace phoenix {
 	protected:
 		friend class symbol;
 
-		virtual void read32(void* data32, symbol const& sym, size_t index) = 0;
-		virtual void write32(const void* data32, symbol const& sym, size_t index) = 0;
+		virtual void set_int(symbol const& sym, uint16_t index, std::int32_t value) = 0;
+		virtual std::int32_t get_int(symbol const& sym, uint16_t index) = 0;
 
-		virtual void write_string(std::string_view str, symbol const& sym, size_t index) = 0;
-		virtual const std::string& read_string(symbol const& sym, size_t index) = 0;
+		virtual void set_float(symbol const& sym, uint16_t index, float value) = 0;
+		virtual float get_float(symbol const& sym, uint16_t index) = 0;
+
+		virtual void set_string(symbol const& sym, uint16_t index, std::string_view value) = 0;
+		virtual const std::string& get_string(symbol const& sym, uint16_t index) = 0;
 	};
 
 	/// \brief The base class for all exceptions thrown by interacting with a script.

--- a/include/phoenix/script.hh
+++ b/include/phoenix/script.hh
@@ -218,12 +218,53 @@ namespace phoenix {
 		void* user_ptr = nullptr;
 
 	private:
+		friend class transient_instance;
 		friend class symbol;
 		friend class script;
 		friend class vm;
 
 		uint32_t _m_symbol_index {unset};
 		const std::type_info* _m_type {nullptr};
+	};
+
+	/// \brief Represents an object associated with an instance in the script.
+	///
+	/// Instances allocated with init_opaque will be backed up by this class with plain memory storage
+	class opaque_instance final : public instance {
+	public:
+		PHOENIX_INTERNAL opaque_instance(symbol const& sym, std::vector<symbol*> const& members);
+		PHOENIX_INTERNAL ~opaque_instance();
+
+		PHOENIX_INTERNAL std::uint8_t* data() {
+			return _m_storage.get();
+		}
+
+		PHOENIX_INTERNAL const std::uint8_t* data() const {
+			return _m_storage.get();
+		}
+
+	private:
+		template <typename T, typename... Args>
+		PHOENIX_INTERNAL T* construct_at(size_t offset, Args&&... args);
+
+		std::unique_ptr<std::uint8_t[]> _m_storage;
+		std::unique_ptr<std::string*[]> _m_strings;
+		size_t _m_str_count {0};
+	};
+
+	/// \brief Represents object instance in the script with no defined backing to memory.
+	///
+	/// Expected to be used for DMA mods or to emulate variable-like access to engine-functions.
+	class transient_instance : public instance {
+	public:
+		transient_instance();
+		~transient_instance();
+
+		virtual void read32(void* data32, symbol const& sym, size_t index) = 0;
+		virtual void write32(const void* data32, symbol const& sym, size_t index) = 0;
+
+		virtual void write(std::string_view str, symbol const& sym, size_t index) = 0;
+		virtual const std::string& read(symbol const& sym, size_t index) = 0;
 	};
 
 	/// \brief The base class for all exceptions thrown by interacting with a script.
@@ -573,8 +614,12 @@ namespace phoenix {
 			if (*_m_registered_to != *context->_m_type)
 				throw illegal_context_type {this, *context->_m_type};
 
+			auto data_ptr = reinterpret_cast<const uint8_t*>(context.get());
+			if (_m_registered_to == &typeid(opaque_instance)) {
+				data_ptr = reinterpret_cast<const opaque_instance*>(data_ptr)->data();
+			}
 			std::uint32_t target_offset = offset_as_member() + index * sizeof(T);
-			return reinterpret_cast<const T*>(reinterpret_cast<const char*>(context.get()) + target_offset);
+			return reinterpret_cast<const T*>(data_ptr + target_offset);
 		}
 
 		template <typename T>
@@ -584,8 +629,12 @@ namespace phoenix {
 			if (*_m_registered_to != *context->_m_type)
 				throw illegal_context_type {this, *context->_m_type};
 
+			auto data_ptr = reinterpret_cast<uint8_t*>(context.get());
+			if (_m_registered_to == &typeid(opaque_instance)) {
+				data_ptr = reinterpret_cast<opaque_instance*>(data_ptr)->data();
+			}
 			std::uint32_t target_offset = offset_as_member() + index * sizeof(T);
-			return reinterpret_cast<T*>(reinterpret_cast<char*>(context.get()) + target_offset);
+			return reinterpret_cast<T*>(data_ptr + target_offset);
 		}
 
 	private:
@@ -791,6 +840,14 @@ namespace phoenix {
 		        const std::shared_ptr<T>& inst) {
 			return find_symbol_by_index(inst->_m_symbol_index);
 		}
+
+		[[nodiscard]] PHOENIX_API std::vector<symbol*> find_class_members(symbol const& cls);
+
+		void register_as_opaque(std::string_view class_name) {
+			return register_as_opaque(find_symbol_by_name(class_name));
+		}
+
+		void register_as_opaque(symbol* sym);
 
 	protected:
 		PHOENIX_INTERNAL script() = default;

--- a/include/phoenix/vm.hh
+++ b/include/phoenix/vm.hh
@@ -336,20 +336,6 @@ namespace phoenix {
 		[[nodiscard]] PHOENIX_API const std::string& pop_string();
 		[[nodiscard]] PHOENIX_API std::tuple<symbol*, std::uint8_t, std::shared_ptr<instance>> pop_reference();
 
-		[[nodiscard]] PHOENIX_API std::int32_t
-		get_int(std::shared_ptr<instance>& context,
-		        std::variant<int32_t, float, symbol*, std::shared_ptr<instance>>& value,
-		        uint16_t index);
-		[[nodiscard]] PHOENIX_API float
-		get_float(std::shared_ptr<instance>& context,
-		          std::variant<int32_t, float, symbol*, std::shared_ptr<instance>>& value,
-		          uint16_t index);
-
-		PHOENIX_API void set_int(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, std::int32_t value);
-		PHOENIX_API void set_float(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, float value);
-		PHOENIX_API void
-		set_string(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, std::string_view value);
-
 		/// \brief Registers a Daedalus external function.
 		///
 		/// <p>External functions are a way for Daedalus scripts to execute more complicated code in the C++ world
@@ -977,6 +963,20 @@ namespace phoenix {
 				return pop_string();
 			}
 		}
+
+		[[nodiscard]] PHOENIX_API std::int32_t
+		get_int(std::shared_ptr<instance>& context,
+		        std::variant<int32_t, float, symbol*, std::shared_ptr<instance>>& value,
+		        uint16_t index);
+		[[nodiscard]] PHOENIX_API float
+		get_float(std::shared_ptr<instance>& context,
+		          std::variant<int32_t, float, symbol*, std::shared_ptr<instance>>& value,
+		          uint16_t index);
+
+		PHOENIX_API void set_int(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, std::int32_t value);
+		PHOENIX_API void set_float(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, float value);
+		PHOENIX_API void
+		set_string(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, std::string_view value);
 
 	private:
 		std::array<daedalus_stack_frame, stack_size> _m_stack;

--- a/include/phoenix/vm.hh
+++ b/include/phoenix/vm.hh
@@ -330,6 +330,13 @@ namespace phoenix {
 		[[nodiscard]] PHOENIX_API const std::string& pop_string();
 		[[nodiscard]] PHOENIX_API std::tuple<symbol*, std::uint8_t, std::shared_ptr<instance>> pop_reference();
 
+		[[nodiscard]] PHOENIX_API std::int32_t get_int(std::shared_ptr<instance>& context,
+													   std::variant<int32_t, float, symbol*, std::shared_ptr<instance> >& value,
+													   uint16_t index);
+
+		PHOENIX_API void set_int(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, std::int32_t value);
+		PHOENIX_API void set_string(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, std::string_view value);
+
 		/// \brief Registers a Daedalus external function.
 		///
 		/// <p>External functions are a way for Daedalus scripts to execute more complicated code in the C++ world
@@ -626,6 +633,12 @@ namespace phoenix {
 		PHOENIX_API void register_default_external_custom(const std::function<void(vm&, symbol&)>& callback);
 
 		PHOENIX_API void register_access_trap(const std::function<void (symbol &)> &callback);
+
+		PHOENIX_API void register_memory_trap(const std::function<void(std::int32_t, std::size_t, const std::shared_ptr<instance>&, symbol&)> &callback);
+		PHOENIX_API void register_memory_trap(const std::function<std::int32_t(std::size_t, const std::shared_ptr<instance>&, symbol&)>& callback);
+
+		PHOENIX_API void register_memory_trap(const std::function<void(std::string_view, std::size_t, const std::shared_ptr<instance>&, symbol&)> &callback);
+		PHOENIX_API void register_memory_trap(const std::function<const std::string&(std::size_t, const std::shared_ptr<instance>&, symbol&)> &callback);
 
 		/// \brief Registers a function to be called when script execution fails.
 		///
@@ -950,6 +963,11 @@ namespace phoenix {
 		std::function<void(symbol&)> _m_access_trap;
 		std::optional<std::function<vm_exception_strategy(vm&, const script_error&, const instruction&)>>
 		    _m_exception_handler {std::nullopt};
+
+		std::function<void(std::int32_t, std::size_t, const std::shared_ptr<instance>&, symbol&)> _m_memory_trap;
+		std::function<std::int32_t(std::size_t, const std::shared_ptr<instance>&, symbol&)> _m_memory_trap_read;
+		std::function<void(std::string_view, std::size_t, const std::shared_ptr<instance>&, symbol&)> _m_memory_trap_s;
+		std::function<const std::string&(std::size_t, const std::shared_ptr<instance>&, symbol&)> _m_memory_trap_read_s;
 
 		symbol* _m_self_sym;
 		symbol* _m_other_sym;

--- a/include/phoenix/vm.hh
+++ b/include/phoenix/vm.hh
@@ -347,7 +347,8 @@ namespace phoenix {
 
 		PHOENIX_API void set_int(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, std::int32_t value);
 		PHOENIX_API void set_float(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, float value);
-		PHOENIX_API void set_string(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, std::string_view value);
+		PHOENIX_API void
+		set_string(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, std::string_view value);
 
 		/// \brief Registers a Daedalus external function.
 		///

--- a/include/phoenix/vm.hh
+++ b/include/phoenix/vm.hh
@@ -334,11 +334,17 @@ namespace phoenix {
 		[[nodiscard]] PHOENIX_API const std::string& pop_string();
 		[[nodiscard]] PHOENIX_API std::tuple<symbol*, std::uint8_t, std::shared_ptr<instance>> pop_reference();
 
-		[[nodiscard]] PHOENIX_API std::int32_t get_int(std::shared_ptr<instance>& context,
-													   std::variant<int32_t, float, symbol*, std::shared_ptr<instance> >& value,
-													   uint16_t index);
+		[[nodiscard]] PHOENIX_API std::int32_t
+		get_int(std::shared_ptr<instance>& context,
+		        std::variant<int32_t, float, symbol*, std::shared_ptr<instance>>& value,
+		        uint16_t index);
+		[[nodiscard]] PHOENIX_API float
+		get_float(std::shared_ptr<instance>& context,
+		          std::variant<int32_t, float, symbol*, std::shared_ptr<instance>>& value,
+		          uint16_t index);
 
 		PHOENIX_API void set_int(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, std::int32_t value);
+		PHOENIX_API void set_float(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, float value);
 		PHOENIX_API void set_string(std::shared_ptr<instance>& context, symbol* ref, uint16_t index, std::string_view value);
 
 		/// \brief Registers a Daedalus external function.
@@ -638,11 +644,16 @@ namespace phoenix {
 
 		PHOENIX_API void register_access_trap(const std::function<void(symbol&)>& callback);
 
-		PHOENIX_API void register_memory_trap(const std::function<void(std::int32_t, std::size_t, const std::shared_ptr<instance>&, symbol&)> &callback);
-		PHOENIX_API void register_memory_trap(const std::function<std::int32_t(std::size_t, const std::shared_ptr<instance>&, symbol&)>& callback);
+		PHOENIX_API void register_memory_trap_write(
+		    const std::function<void(const void*, std::size_t, const std::shared_ptr<instance>&, symbol&)>& callback);
+		PHOENIX_API void register_memory_trap_read(
+		    const std::function<void(void*, std::size_t, const std::shared_ptr<instance>&, symbol&)>& callback);
 
-		PHOENIX_API void register_memory_trap(const std::function<void(std::string_view, std::size_t, const std::shared_ptr<instance>&, symbol&)> &callback);
-		PHOENIX_API void register_memory_trap(const std::function<const std::string&(std::size_t, const std::shared_ptr<instance>&, symbol&)> &callback);
+		PHOENIX_API void register_memory_trap_write(
+		    const std::function<void(std::string_view, std::size_t, const std::shared_ptr<instance>&, symbol&)>&
+		        callback);
+		PHOENIX_API void register_memory_trap_read(
+		    const std::function<const std::string&(std::size_t, const std::shared_ptr<instance>&, symbol&)>& callback);
 
 		/// \brief Registers a function to be called when script execution fails.
 		///
@@ -987,10 +998,12 @@ namespace phoenix {
 		std::optional<std::function<vm_exception_strategy(vm&, const script_error&, const instruction&)>>
 		    _m_exception_handler {std::nullopt};
 
-		std::function<void(std::int32_t, std::size_t, const std::shared_ptr<instance>&, symbol&)> _m_memory_trap;
-		std::function<std::int32_t(std::size_t, const std::shared_ptr<instance>&, symbol&)> _m_memory_trap_read;
-		std::function<void(std::string_view, std::size_t, const std::shared_ptr<instance>&, symbol&)> _m_memory_trap_s;
-		std::function<const std::string&(std::size_t, const std::shared_ptr<instance>&, symbol&)> _m_memory_trap_read_s;
+		std::function<void(const void* data32, std::size_t, const std::shared_ptr<instance>&, symbol&)>
+		    _m_memory_trap_set32;
+		std::function<void(void* data32, std::size_t, const std::shared_ptr<instance>&, symbol&)> _m_memory_trap_get32;
+		std::function<void(std::string_view, std::size_t, const std::shared_ptr<instance>&, symbol&)>
+		    _m_memory_trap_set_s;
+		std::function<const std::string&(std::size_t, const std::shared_ptr<instance>&, symbol&)> _m_memory_trap_get_s;
 
 		symbol* _m_self_sym;
 		symbol* _m_other_sym;

--- a/include/phoenix/vm.hh
+++ b/include/phoenix/vm.hh
@@ -205,6 +205,8 @@ namespace phoenix {
 			return inst;
 		}
 
+		std::shared_ptr<instance> init_opaque_instance(symbol* sym);
+
 		/// \brief Initializes an instance with the given type into \p instance
 		/// \tparam _instance_t The type of the instance to initialize (ie. C_NPC).
 		/// \param instance The instance to initialize.
@@ -644,17 +646,6 @@ namespace phoenix {
 
 		PHOENIX_API void register_access_trap(const std::function<void(symbol&)>& callback);
 
-		PHOENIX_API void register_memory_trap_write(
-		    const std::function<void(const void*, std::size_t, const std::shared_ptr<instance>&, symbol&)>& callback);
-		PHOENIX_API void register_memory_trap_read(
-		    const std::function<void(void*, std::size_t, const std::shared_ptr<instance>&, symbol&)>& callback);
-
-		PHOENIX_API void register_memory_trap_write(
-		    const std::function<void(std::string_view, std::size_t, const std::shared_ptr<instance>&, symbol&)>&
-		        callback);
-		PHOENIX_API void register_memory_trap_read(
-		    const std::function<const std::string&(std::size_t, const std::shared_ptr<instance>&, symbol&)>& callback);
-
 		/// \brief Registers a function to be called when script execution fails.
 		///
 		/// A variety of exceptions can occur within the VM while executing. The function passed to this handler can
@@ -997,13 +988,6 @@ namespace phoenix {
 		std::function<void(symbol&)> _m_access_trap;
 		std::optional<std::function<vm_exception_strategy(vm&, const script_error&, const instruction&)>>
 		    _m_exception_handler {std::nullopt};
-
-		std::function<void(const void* data32, std::size_t, const std::shared_ptr<instance>&, symbol&)>
-		    _m_memory_trap_set32;
-		std::function<void(void* data32, std::size_t, const std::shared_ptr<instance>&, symbol&)> _m_memory_trap_get32;
-		std::function<void(std::string_view, std::size_t, const std::shared_ptr<instance>&, symbol&)>
-		    _m_memory_trap_set_s;
-		std::function<const std::string&(std::size_t, const std::shared_ptr<instance>&, symbol&)> _m_memory_trap_get_s;
 
 		symbol* _m_self_sym;
 		symbol* _m_other_sym;

--- a/source/script.cc
+++ b/source/script.cc
@@ -399,7 +399,7 @@ namespace phoenix {
 			}
 
 			if (context->symbol_index() == unset && context->_m_type == &typeid(transient_instance)) {
-				return reinterpret_cast<transient_instance&>(*context).read(*this, index);
+				return reinterpret_cast<transient_instance&>(*context).read_string(*this, index);
 			}
 
 			return *get_member_ptr<std::string>(index, context);
@@ -472,7 +472,7 @@ namespace phoenix {
 			}
 
 			if (context->symbol_index() == unset && context->_m_type == &typeid(transient_instance)) {
-				reinterpret_cast<transient_instance&>(*context).write(value, *this, index);
+				reinterpret_cast<transient_instance&>(*context).write_string(value, *this, index);
 				return;
 			}
 
@@ -562,9 +562,9 @@ namespace phoenix {
 		}
 
 		_m_storage.reset(new uint8_t[sym.class_size()]());
-		_m_strings.reset(new std::string*[str_count]());
+		_m_strings.resize(str_count, nullptr);
 
-		_m_str_count = 0;
+		str_count = 0;
 		for (auto* member : members) {
 			unsigned offset = member->offset_as_member();
 
@@ -579,8 +579,8 @@ namespace phoenix {
 					offset += 4;
 					break;
 				case datatype::string:
-					_m_strings[_m_str_count] = this->construct_at<std::string>(offset, "");
-					_m_str_count++;
+					_m_strings[str_count] = this->construct_at<std::string>(offset, "");
+					str_count++;
 					offset += sizeof(std::string);
 					break;
 				case datatype::function:
@@ -600,8 +600,8 @@ namespace phoenix {
 	}
 
 	opaque_instance::~opaque_instance() {
-		for (size_t i = 0; i < _m_str_count; ++i)
-			_m_strings[i]->std::string::~string();
+		for (auto& i : _m_strings)
+			i->std::string::~string();
 	}
 
 	template <typename T, typename... Args>

--- a/source/script.cc
+++ b/source/script.cc
@@ -399,7 +399,7 @@ namespace phoenix {
 			}
 
 			if (context->symbol_index() == unset && context->_m_type == &typeid(transient_instance)) {
-				return reinterpret_cast<transient_instance&>(*context).read_string(*this, index);
+				return reinterpret_cast<transient_instance&>(*context).get_string(*this, index);
 			}
 
 			return *get_member_ptr<std::string>(index, context);
@@ -422,9 +422,7 @@ namespace phoenix {
 			}
 
 			if (context->symbol_index() == unset && context->_m_type == &typeid(transient_instance)) {
-				int32_t value = 0;
-				reinterpret_cast<transient_instance&>(*context).read32(&value, *this, index);
-				return value;
+				return reinterpret_cast<transient_instance&>(*context).get_float(*this, index);
 			}
 
 			return *get_member_ptr<float>(index, context);
@@ -447,9 +445,7 @@ namespace phoenix {
 			}
 
 			if (context->symbol_index() == unset && context->_m_type == &typeid(transient_instance)) {
-				int32_t value = 0;
-				reinterpret_cast<transient_instance&>(*context).read32(&value, *this, index);
-				return value;
+				return reinterpret_cast<transient_instance&>(*context).get_int(*this, index);
 			}
 
 			return *get_member_ptr<std::int32_t>(index, context);
@@ -472,7 +468,7 @@ namespace phoenix {
 			}
 
 			if (context->symbol_index() == unset && context->_m_type == &typeid(transient_instance)) {
-				reinterpret_cast<transient_instance&>(*context).write_string(value, *this, index);
+				reinterpret_cast<transient_instance&>(*context).set_string(*this, index, value);
 				return;
 			}
 
@@ -496,7 +492,7 @@ namespace phoenix {
 			}
 
 			if (context->symbol_index() == unset && context->_m_type == &typeid(transient_instance)) {
-				reinterpret_cast<transient_instance&>(*context).write32(&value, *this, index);
+				reinterpret_cast<transient_instance&>(*context).set_float(*this, index, value);
 				return;
 			}
 
@@ -520,7 +516,7 @@ namespace phoenix {
 			}
 
 			if (context->symbol_index() == unset && context->_m_type == &typeid(transient_instance)) {
-				reinterpret_cast<transient_instance&>(*context).write32(&value, *this, index);
+				reinterpret_cast<transient_instance&>(*context).set_int(*this, index, value);
 				return;
 			}
 

--- a/source/vm.cc
+++ b/source/vm.cc
@@ -84,8 +84,13 @@ namespace phoenix {
 
 	std::shared_ptr<instance> vm::init_opaque_instance(symbol* sym) {
 		auto cls = sym;
-		if (cls->type() == datatype::instance) {
+		while (cls != nullptr && cls->type() == datatype::class_) {
 			cls = find_symbol_by_index(cls->parent());
+		}
+		if (cls == nullptr) {
+			// We're probably trying to initialize $INSTANCE_HELP which is not permitted
+			throw vm_exception {"Cannot init " + sym->name() +
+			                    ": parent class not found (did you try to initialize $INSTANCE_HELP?)"};
 		}
 		// create the instance
 		auto inst = std::make_shared<opaque_instance>(*cls, find_class_members(*cls));

--- a/source/vm.cc
+++ b/source/vm.cc
@@ -84,7 +84,7 @@ namespace phoenix {
 
 	std::shared_ptr<instance> vm::init_opaque_instance(symbol* sym) {
 		auto cls = sym;
-		while (cls != nullptr && cls->type() == datatype::class_) {
+		while (cls != nullptr && cls->type() != datatype::class_) {
 			cls = find_symbol_by_index(cls->parent());
 		}
 		if (cls == nullptr) {

--- a/source/vm.cc
+++ b/source/vm.cc
@@ -304,7 +304,7 @@ namespace phoenix {
 
 				if (ref->is_const() && !(_m_flags & execution_flag::vm_ignore_const_specifier)) {
 					throw illegal_const_access(ref);
-        }
+				}
 
 				if (!ref->is_member() || context != nullptr ||
 				    !(_m_flags & execution_flag::vm_allow_null_instance_access)) {
@@ -617,8 +617,7 @@ namespace phoenix {
 			throw illegal_const_access(ref);
 		}
 
-		if (!ref->is_member() || context != nullptr ||
-			!(_m_flags & execution_flag::vm_allow_null_instance_access)) {
+		if (!ref->is_member() || context != nullptr || !(_m_flags & execution_flag::vm_allow_null_instance_access)) {
 			ref->set_int(value, index, context);
 		} else if (ref->is_member()) {
 			PX_LOGE("vm: accessing member \"", ref->name(), "\" without an instance set");


### PR DESCRIPTION
This PR introduces 2 new special types for instances:
1. `opaque_instance` - almost same as you propose in ticket, intended as replacement for `C_SVM`, `C_FightAi`
2. `transient_instance` - callback-based workflow, that delegates read/write operations to the engine.

When working on Ikarus support, there are several use-cases:
* Simple `opaque_instance`, like `C_SVM` - works straight
* Simple `transient_instance` - allocated via mem32 framework, works straight
* Hybrids, CoM sometimes instantiates `C_ITEM` for speculative purposes (get description). This creates scenario when some `C_ITEM` instances are 'normal' instances and some - transient. Should work, as mapping done at `symbol::get_*`/`symbol::set_` level.
* Mapping; when simple instance created in normal flow suppose to be mapped into mem32. OpenGothic can intercept take-pointer operator( `_@` ) and create projection as `transient_instance`